### PR TITLE
Round end logic change

### DIFF
--- a/lib/game/channel_event_handler.ex
+++ b/lib/game/channel_event_handler.ex
@@ -17,13 +17,15 @@ defmodule Reactor.ChannelEventHandler do
   end
 
   def handle_event({:new_round, %{game_id: game_id, colors: colors, instruction: instruction}}) do
-    game_id = game_id |> String.replace_leading("game-", "")
-
     GameChannel.broadcast_new_round(game_id, %{colors: colors, instruction: instruction})
   end
 
-  def handle_event({:winner, %{user: user, game_id: game_id}}) do
-    GameChannel.broadcast_winner(game_id, %{user: user})
+  def handle_event({:round_handled, %{winner: winner, game_id: game_id}}) do
+    GameChannel.broadcast_winner(game_id, %{user: winner})
+  end
+
+  def handle_event({:round_handled, %{game_id: game_id}}) do
+    GameChannel.broadcast_winner(game_id, %{user: "No one"})
   end
 
   def handle_event({:new_game, _state}) do

--- a/lib/game/game_manager.ex
+++ b/lib/game/game_manager.ex
@@ -77,6 +77,12 @@ defmodule Reactor.GameManager do
     |> GenServer.cast({:handle_winner, %{winner: winner}})
   end
 
+  def handle_no_winner(game_id) do
+    game_id
+    |> RefHelper.to_game_ref
+    |> GenServer.cast({:handle_no_winner})
+  end
+
   ##server callbacks
 
   def init(:ok) do

--- a/lib/game/games_event_handler.ex
+++ b/lib/game/games_event_handler.ex
@@ -16,12 +16,12 @@ defmodule Reactor.GamesEventHandler do
     {:consumer, :ok, subscribe_to: [Reactor.EventManager]}
   end
 
-  def handle_event({:winner, %{game_id: game_id, user: user}}) do
+  def handle_event({:winner, %{user: user, game_id: game_id}}) do
     GameManager.handle_winner(game_id, user)
   end
 
   def handle_event({:no_winner, %{game_id: game_id}}) do
-    GameManager.start_round(game_id)
+    GameManager.handle_no_winner(game_id)
   end
 
   def handle_event(_) do

--- a/test/lib/game/game_manager_test.exs
+++ b/test/lib/game/game_manager_test.exs
@@ -59,4 +59,16 @@ defmodule Reactor.GameManagerTest do
 
     assert user.score == 1
   end
+
+  test "readys users in a game", game do
+    GameManager.add_user_to_game(game.id, "User")
+    {:ok, %{"User" => user}} = GameManager.get_users(game.id)
+
+    refute user[:ready]
+
+    GameManager.ready_user(game.id, "User")
+    {:ok, %{"User" => user}} = GameManager.get_users(game.id)
+
+    assert user[:ready]
+  end
 end

--- a/web/channels/game_channel.ex
+++ b/web/channels/game_channel.ex
@@ -67,6 +67,13 @@ defmodule Reactor.GameChannel do
     {:noreply, socket}
   end
 
+  def handle_in("new:winner_received", _msg, socket) do
+    %{user: user, game_id: game_id} = socket.assigns
+    GameManager.ready_user(game_id, user)
+
+    {:noreply, socket}
+  end
+
   def handle_info({:after_join, _msg}, socket) do
     push(socket, "new:message", %{message: "Welcome! Please wait for users to join"})
 

--- a/web/static/js/game.js
+++ b/web/static/js/game.js
@@ -60,6 +60,7 @@ class Game extends Component {
 
     this.channel.on("new:winner", (msg) => {
       const { messages } = this.state;
+      this.channel.push("new:winner_received");
 
       this.setState({
         messages: concat(messages, `${msg.user} is the winner!`),


### PR DESCRIPTION
Theres a change in round ending logic:

1) Round dies and emits the winner
2) Game updates the score and emits the updated score
3) Channel dispatches the winner and score
4) Client acks receipt
5) Game updates user ready per ack
6) Game starts round when all users ready
